### PR TITLE
[JULES] Refactor: Replace save button loading indicator with toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "pocketbase": "^0.26.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hot-toast": "^2.5.2",
         "react-router-dom": "^7.5.1"
       },
       "devDependencies": {
@@ -4460,6 +4461,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -5593,6 +5602,22 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "pocketbase": "^0.26.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hot-toast": "^2.5.2",
     "react-router-dom": "^7.5.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { HomePage } from "@src/pages/HomePage";
 import { TranscriptEditPage } from "@src/pages/TranscriptEditPage";
 import { transcriptApi } from "@src/services/api";
 import { createContext } from "react";
+import { Toaster } from 'react-hot-toast';
 
 export const APIContext = createContext(transcriptApi);
 function App() {
@@ -16,6 +17,7 @@ function App() {
       <BrowserRouter>
         <APIContext.Provider value={transcriptApi}>
           <Layout>
+            <Toaster position="top-center" />
             <Routes>
               <Route path="/" element={<HomePage />} />
               <Route path="/transcript/:id" element={<TranscriptEditPage />} />

--- a/src/pages/TranscriptEditPage.tsx
+++ b/src/pages/TranscriptEditPage.tsx
@@ -22,6 +22,7 @@ import {
   IconFileWord,
 } from "@tabler/icons-react";
 import { countWords } from "@src/utils/word_count";
+import toast from 'react-hot-toast';
 
 export function TranscriptEditPage() {
   const transcriptApi = useContext(APIContext);
@@ -35,7 +36,6 @@ export function TranscriptEditPage() {
   const [loading, setLoading] = useState(true);
   const [refining, setRefining] = useState(false);
   const [exporting, setExporting] = useState(false);
-  const [saving, setSaving] = useState(false);
   // Segment tracking to allow scrolling to the active segment based on audio time
   const [activeSegmentId, setActiveSegmentId] = useState<number>(0);
   const segmentRefs = useRef<Map<number, HTMLTextAreaElement>>(new Map());
@@ -175,19 +175,19 @@ export function TranscriptEditPage() {
     if (!id || !transcript) return;
 
     try {
-      setSaving(true);
       getEditedSegmentData();
       const savedTranscript = await transcriptApi.saveTranscriptEdits(
         id,
         transcript.segments
       );
       setTranscript(savedTranscript);
+      toast.success("Changes Saved");
       setError("");
     } catch (err) {
       console.error("Failed to save transcript:", err);
+      toast.error("Error saving changes");
       setError("Failed to save transcript");
     } finally {
-      setSaving(false);
     }
   };
 
@@ -231,8 +231,6 @@ export function TranscriptEditPage() {
         <Group>
           <Button
             onClick={handleSave}
-            loading={saving}
-            disabled={saving}
             leftSection={<IconDeviceFloppy size={16} />}
           >
             Save


### PR DESCRIPTION
I've replaced the loading indicator on the save button in the TranscriptEditPage with toast notifications.

- I removed the `loading` and `disabled` props from the save button.
- I integrated `react-hot-toast` to display "Changes Saved" on successful save and "Error saving changes" on error.
- I removed the unnecessary `saving` state variable.

This change improves the user experience by providing immediate feedback without the janky loading animation, as saving is a quick operation.